### PR TITLE
Update version_windows.go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.19
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Efe Karakus
+Copyright (c) 2022 Jens Schendel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The same environment variable and flag [priorities](https://github.com/chalk/sup
 ## Credits
 * Originally created by [Efe Karakus](https://www.efekarakus.com/)
 * Edited & republished by [Jens Schendel](https://jens-schendel.com/)
-* Based on [chalk/supports-color](https://github.com/chalk/supports-color/)
+* heavily inspired by [chalk/supports-color](https://github.com/chalk/supports-color/)
 
 ## License
 The MIT License (MIT) - see [LICENSE](https://github.com/jagottsicher/termcolor/blob/master/LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Termcolor [![GoDoc](https://godoc.org/github.com/efekarakus/termcolor?status.svg)](https://godoc.org/github.com/efekarakus/termcolor) [![Actions Status](https://github.com/efekarakus/termcolor/workflows/Go/badge.svg)](https://github.com/efekarakus/termcolor/actions)
+# Termcolor [![GoDoc](https://pkg.go.dev/github.com/jagottsicher/termcolor?status.svg)](https://pkg.go.dev/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions)
 Detects what level of color support your terminal has.
 This package is heavily inspired by [chalk's support-color](https://github.com/chalk/supports-color) module.
 
@@ -50,8 +50,9 @@ The same environment variable and flag [priorities](https://github.com/chalk/sup
 
 
 ## Credits
-* [Efe Karakus](https://www.efekarakus.com/)
-* [chalk/supports-color](https://github.com/chalk/supports-color/)
+* Originally created by [Efe Karakus](https://www.efekarakus.com/)
+* Edited & republished by [Jens Schendel](https://jens-schendel.com/)
+* Based on [chalk/supports-color](https://github.com/chalk/supports-color/)
 
 ## License
-The MIT License (MIT) - see [LICENSE](https://github.com/efekarakus/termcolor/blob/master/LICENSE) for more details.
+The MIT License (MIT) - see [LICENSE](https://github.com/jagottsicher/termcolor/blob/master/LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Termcolor [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions)
+# Termcolor [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions) [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor)
 Detects what level of color support your terminal has.
 This package is heavily inspired by [chalk's support-color](https://github.com/chalk/supports-color) module.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The same environment variable and flag [priorities](https://github.com/chalk/sup
 ## Credits
 * Originally created by [Efe Karakus](https://www.efekarakus.com/)
 * Edited & republished by [Jens Schendel](https://jens-schendel.com/)
-* heavily inspired by [chalk/supports-color](https://github.com/chalk/supports-color/)
+* Heavily inspired by [chalk/supports-color](https://github.com/chalk/supports-color/)
 
 ## License
 The MIT License (MIT) - see [LICENSE](https://github.com/jagottsicher/termcolor/blob/master/LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Termcolor [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions)
+# Termcolor [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/efekarakus/termcolor/workflows/Go/badge.svg)](https://github.com/efekarakus/termcolor/actions)
 Detects what level of color support your terminal has.
 This package is heavily inspired by [chalk's support-color](https://github.com/chalk/supports-color) module.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package is heavily inspired by [chalk's support-color](https://github.com/c
 
 ## Install
 ```sh
-go get github.com/efekarakus/termcolor
+go get github.com/jagottsicher/termcolor
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Termcolor [![GoDoc](https://pkg.go.dev/github.com/jagottsicher/termcolor?status.svg)](https://pkg.go.dev/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions)
+# Termcolor [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions)
 Detects what level of color support your terminal has.
 This package is heavily inspired by [chalk's support-color](https://github.com/chalk/supports-color) module.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Termcolor [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/efekarakus/termcolor/workflows/Go/badge.svg)](https://github.com/efekarakus/termcolor/actions)
+# Termcolor [![GoDoc](https://godoc.org/github.com/jagottsicher/termcolor?status.svg)](https://godoc.org/github.com/jagottsicher/termcolor) [![Actions Status](https://github.com/jagottsicher/termcolor/workflows/Go/badge.svg)](https://github.com/jagottsicher/termcolor/actions)
 Detects what level of color support your terminal has.
 This package is heavily inspired by [chalk's support-color](https://github.com/chalk/supports-color) module.
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/efekarakus/termcolor
+module github.com/jagottsicher/termcolor
 
-go 1.13
+go 1.19
 
 require (
-	github.com/mattn/go-isatty v0.0.10
-	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056
+	github.com/mattn/go-isatty v0.0.16
+	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
-github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
-github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
-golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
-golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 h1:dHtDnRWQtSx0Hjq9kvKFpBh9uPPKfQN70NZZmvssGwk=
-golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/version_windows.go
+++ b/version_windows.go
@@ -11,7 +11,7 @@ import (
 // lookupWindows returns the level of the windows terminal. If the OS is windows, the terminal level is returned and
 // the boolean is set to true. If an error occurs then LevelBasic and true is returned.
 // If the OS is not windows, then LevelNone and false is returned.
-func windowsLevel() (Level, bool) {
+func lookupWindows() (Level, bool) {
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
 	if err != nil {
 		return LevelBasic, true


### PR DESCRIPTION
tiny problem with the go-file in the termcolor package determinating the available colors on windows.
Apparently  lookupWindows() is missnamed in  version_windows.go The "problem is, that the identifier in version.go (non-windows) and version_windows.go (windows terminal cmd and powershell) are NOT the same.

Please see also [the open issue](https://github.com/efekarakus/termcolor/issues/3#issue-1390150793)